### PR TITLE
Fix: round XRP amount to 6 decimal places in useGetXrp hook

### DIFF
--- a/lib/use-get-xrp.ts
+++ b/lib/use-get-xrp.ts
@@ -35,8 +35,9 @@ export const useGetXrp = (network: Network) => {
     await new Promise((res) => setTimeout(res, 1000));
 
     const amount = json.amount - reserve - transferFee;
+    const roundedAmount = Math.round(amount * 1e6) / 1e6;
 
-    const tx = prepareBridgeTransaction(wallet.address, network, destination, amount);
+    const tx = prepareBridgeTransaction(wallet.address, network, destination, roundedAmount);
 
     const client = new Client(networks[network].wsUrl);
     await client.connect();


### PR DESCRIPTION
**PR Title**
Fix: round XRP amount to 6 decimal places in `useGetXrp` hook

---

**PR Description**

**What’s changed**

* After computing the raw XRP amount (`json.amount - reserve - transferFee`), we now round it to 6 decimal places:

  ```ts
  const roundedAmount = Math.round(amount * 1e6) / 1e6;
  ```
* Pass `roundedAmount` (instead of the unrounded `amount`) into `prepareBridgeTransaction`.

**Why**
The XRP Ledger only supports up to 6 decimal places. Floating-point calculations can produce extra precision, which may cause transaction failures or unexpected errors when submitting bridge transactions. Rounding guarantees the amount respects the ledger’s precision requirements.

**How to test**

1. Pull this branch and run the faucet locally.
2. Trigger a GET-XRP request with various amounts (e.g. 0.1234567, 1.0000004).
3. Inspect the prepared transaction payload—`Amount` should never exceed 6 decimal places.
4. Confirm successful submission against your test network.

---

*Feel free to enable edits by maintainers if adjustments are needed.*
