### PR TITLE
Fix XRP calculation logic and update expected faucet amount

### DIFF
--- a/lib/use-get-xrp.ts
+++ b/lib/use-get-xrp.ts
@@ -16,7 +16,6 @@ const networks = {
 };
 
 const reserve = 1;
-const transferFee = 1.7;
 
 export type Network = "devnet" | "testnet";
 
@@ -34,7 +33,7 @@ export const useGetXrp = (network: Network) => {
 
     await new Promise((res) => setTimeout(res, 1000));
 
-    const amount = json.amount - reserve - transferFee;
+    const amount = json.amount - reserve;
     const roundedAmount = Math.round(amount * 1e6) / 1e6;
 
     const tx = prepareBridgeTransaction(wallet.address, network, destination, roundedAmount);

--- a/lib/use-poll-destination-tx-status.ts
+++ b/lib/use-poll-destination-tx-status.ts
@@ -39,7 +39,7 @@ export function usePollDestinationTxStatus(
     if (!destinationAddress || !sourceCloseTimeIso || !txHash) return;
 
     let attempts = 0;
-    const faucetAmount = 89.50589; // expected faucet amount
+    const faucetAmount = 7.3; // expected faucet amount
 
     const poll = async () => {
       attempts++;


### PR DESCRIPTION
**PR Title**
Fix XRP calculation logic and update expected faucet amount

**PR Description**
This PR makes two related improvements to the xrplevm faucet flow:

1. **Remove transfer fee deduction**
   In `lib/use-get-xrp.ts`, we no longer subtract the `transferFee` from the amount sent to the destination. Now, the code only applies the `reserve` deduction, so users receive the full amount they request minus the network reserve.

2. **Align expected faucet amount**
   In `lib/use-poll-destination-tx-status.ts`, the `faucetAmount` constant has been updated from `89.50589` to `7.3` to match the current faucet configuration.

These changes ensure that the on-chain amount received matches the faucet’s output and prevents discrepancies in status polling. Let me know if you’d like any further adjustments!
