### PR TITLE
Remove Devnet support from Faucet (temporary)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { Faucet } from "@/components/faucet";
 import { Footer } from "@/components/footer";
 
 export default function Home() {
-  const [network, setNetwork] = useState<"Devnet" | "Testnet">("Testnet");
+  const [network, setNetwork] = useState<"Testnet">("Testnet");
 
   // We’ll track if we are mounted so SSR doesn’t mismatch client logic
   const [isMounted, setIsMounted] = useState(false);

--- a/components/bridging-progress.tsx
+++ b/components/bridging-progress.tsx
@@ -7,11 +7,8 @@ import { cn } from "@/lib/utils";
 const FACTS = [
   "XRP on XRPL has 1 million drops per XRP (6 decimals), on XRPL EVM it has 18 decimals.",
   "XRPL EVM Testnet chain id is 1449000.",
-  "XRPL EVM Devnet chain id is 1440002.",
   "XRPL Testnet's chain id in Axelar is xrpl.",
-  "XRPL Devnet's chain id in Axelar is xrpl-dev.",
   "XRPL EVM Testnet's chain id in Axelar is xrpl-evm.",
-  "XRPL EVM Devnet's chain id in Axelar is xrpl-evm-devnet.",
   "All OpenZeppelin contracts can be used and deployed on the XRPL EVM.",
   "XRPL EVM's current EVM Version is Paris.",
   "XRPL EVM is a Cosmos-SDK blockchain with an EVM module by Evmos.",

--- a/components/faucet.tsx
+++ b/components/faucet.tsx
@@ -12,7 +12,7 @@ import { Input } from "./ui/input";
 import Link from "next/link";
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 
-export type NetworkType = "Devnet" | "Testnet";
+export type NetworkType = "Testnet";
 
 interface FaucetProps {
   network: NetworkType;
@@ -45,7 +45,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   const ethereum = getEthereumProvider();
   const hasMetaMask: boolean = Boolean(ethereum);
 
-  const getXrp = useGetXrp(network.toLowerCase() as "devnet" | "testnet");
+  const getXrp = useGetXrp(network.toLowerCase() as "testnet");
 
   useEffect(() => {
     setEvmAddress(evmAddressFromHeader || "");
@@ -109,7 +109,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   };
 
   function getDesiredChainId(network: NetworkType): string {
-    return network === "Devnet" ? "0x" + Number(1440002).toString(16) : "0x" + Number(1449000).toString(16);
+    return "0x" + Number(1449000).toString(16);
   }
   const desiredChainId: string = getDesiredChainId(network);
   const isOnDesiredChain: boolean = !!chainId && chainId.toLowerCase() === desiredChainId.toLowerCase();
@@ -232,21 +232,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
             <MetamaskButton className="h-10" network={network} />
           )}
         </div>
-        <div className="flex flex-col items-center gap-2">
-          <label htmlFor="network" className="font-semibold">
-            Select Network
-          </label>
 
-          <Select value={network} onValueChange={(value: string) => setNetwork(value as NetworkType)}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select Network" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="Devnet">Devnet</SelectItem>
-              <SelectItem value="Testnet">Testnet</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
         <div className="flex flex-col items-center gap-1">
           <label htmlFor="evmAddress" className="font-semibold">
             Your Address

--- a/components/metamask-button.tsx
+++ b/components/metamask-button.tsx
@@ -17,18 +17,6 @@ declare global {
 const INSTALL_METAMASK_URL = "https://docs.xrplevm.org/pages/users/getting-started/install-metamask";
 
 // ✅ Quick config references:
-const DEVNET_CONFIG = {
-  chainId: "0x" + Number(1440002).toString(16),
-  chainName: "XRPL EVM Sidechain Devnet",
-  nativeCurrency: {
-    name: "XRP",
-    symbol: "XRP",
-    decimals: 18,
-  },
-  rpcUrls: ["https://rpc.xrplevm.org/"],
-  blockExplorerUrls: ["https://explorer.xrplevm.org"],
-};
-
 const TESTNET_CONFIG = {
   chainId: "0x" + Number(1449000).toString(16),
   chainName: "XRPL EVM Sidechain Testnet",
@@ -41,7 +29,7 @@ const TESTNET_CONFIG = {
   blockExplorerUrls: ["https://explorer.testnet.xrplevm.org"],
 };
 
-type NetworkType = "Devnet" | "Testnet";
+type NetworkType = "Testnet";
 
 /** 
  * ✅ Common logic for requesting a network add/switch in MetaMask
@@ -53,7 +41,7 @@ async function addNetworkToMetamask(network: NetworkType) {
     return;
   }
 
-  const selectedConfig = network === "Devnet" ? DEVNET_CONFIG : TESTNET_CONFIG;
+  const selectedConfig = TESTNET_CONFIG;
 
   try {
     await window.ethereum.request({

--- a/lib/use-get-xrp.ts
+++ b/lib/use-get-xrp.ts
@@ -1,12 +1,6 @@
 import { Client, Payment, Wallet, xrpToDrops } from "xrpl";
 
 const networks = {
-  devnet: {
-    faucet: "https://faucet.devnet.rippletest.net/accounts",
-    bridgeGateway: "rGAbJZEzU6WaYv5y1LfyN7LBBcQJ3TxsKC",
-    bridgeNetwork: "xrpl-evm-devnet",
-    wsUrl: "wss://s.devnet.rippletest.net:51233/",
-  },
   testnet: {
     faucet: "https://faucet.altnet.rippletest.net/accounts",
     bridgeGateway: "rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2",
@@ -17,7 +11,7 @@ const networks = {
 
 const reserve = 1;
 
-export type Network = "devnet" | "testnet";
+export type Network = "testnet";
 
 export const useGetXrp = (network: Network) => {
   return async function (destination: string) {

--- a/lib/use-poll-destination-tx-status.ts
+++ b/lib/use-poll-destination-tx-status.ts
@@ -18,7 +18,7 @@ const MAX_POLL_ATTEMPTS = 300; // maximum attempts
  * @param destinationAddress - The user's 0x address receiving funds.
  * @param sourceCloseTimeIso - The close_time_iso from the XRPL transaction.
  * @param txHash - The original XRPL transaction hash.
- * @param network - Either "Devnet" or "Testnet".
+ * @param network - Testnet.
  *
  * @returns An object with:
  *  - status: "Pending", "Arrived", "Timeout", or "Failed"
@@ -29,7 +29,7 @@ export function usePollDestinationTxStatus(
   destinationAddress: string,
   sourceCloseTimeIso: string,
   txHash: string,
-  network: "Devnet" | "Testnet"
+  network: "Testnet"
 ) {
   const [status, setStatus] = useState<"Pending" | "Arrived" | "Timeout" | "Failed">("Pending");
   const [destinationTxHash, setDestinationTxHash] = useState<string | null>(null);
@@ -46,15 +46,8 @@ export function usePollDestinationTxStatus(
 
       try {
         // 1) Construct the explorer API URL based on network.
-        let explorerBaseUrl: string;
-        let tokenAddress: string;
-        if (network === "Devnet") {
-          explorerBaseUrl = "https://explorer.xrplevm.org/api/v2/addresses";
-          tokenAddress = "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517";
-        } else {
-          explorerBaseUrl = "https://explorer.testnet.xrplevm.org/api/v2/addresses";
-          tokenAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
-        }
+        const explorerBaseUrl = "https://explorer.testnet.xrplevm.org/api/v2/addresses";
+        const tokenAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
         const url =
           `${explorerBaseUrl}/${destinationAddress}/token-transfers` +
           `?type=ERC-20` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "0.563.0",
-        "next": "16.1.4",
+        "next": "16.1.6",
         "next-themes": "0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -32,7 +32,7 @@
         "@types/react": "19.2.9",
         "@types/react-dom": "19.2.3",
         "eslint": "9.39.2",
-        "eslint-config-next": "16.1.4",
+        "eslint-config-next": "16.1.6",
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3"
       }
@@ -1281,15 +1281,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.4.tgz",
-      "integrity": "sha512-gkrXnZyxPUy0Gg6SrPQPccbNVLSP3vmW8LU5dwEttEEC1RwDivk8w4O+sZIjFvPrSICXyhQDCG+y3VmjlJf+9A==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.4.tgz",
-      "integrity": "sha512-38WMjGP8y+1MN4bcZFs+GTcBe0iem5GGTzFE5GWW/dWdRKde7LOXH3lQT2QuoquVWyfl2S0fQRchGmeacGZ4Wg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1297,9 +1297,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.4.tgz",
-      "integrity": "sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.4.tgz",
-      "integrity": "sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -1329,9 +1329,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.4.tgz",
-      "integrity": "sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -1345,9 +1345,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.4.tgz",
-      "integrity": "sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -1361,9 +1361,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.4.tgz",
-      "integrity": "sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -1377,9 +1377,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.4.tgz",
-      "integrity": "sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -1393,9 +1393,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.4.tgz",
-      "integrity": "sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -1409,9 +1409,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.4.tgz",
-      "integrity": "sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -4317,13 +4317,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.4.tgz",
-      "integrity": "sha512-iCrrNolUPpn/ythx0HcyNRfUBgTkaNBXByisKUbusPGCl8DMkDXXAu7exlSTSLGTIsH9lFE/c4s/3Qiyv2qwdA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
+      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.4",
+        "@next/eslint-plugin-next": "16.1.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -6346,12 +6346,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.4.tgz",
-      "integrity": "sha512-gKSecROqisnV7Buen5BfjmXAm7Xlpx9o2ueVQRo5DxQcjC8d330dOM1xiGWc2k3Dcnz0In3VybyRPOsudwgiqQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.4",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
@@ -6365,14 +6365,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.4",
-        "@next/swc-darwin-x64": "16.1.4",
-        "@next/swc-linux-arm64-gnu": "16.1.4",
-        "@next/swc-linux-arm64-musl": "16.1.4",
-        "@next/swc-linux-x64-gnu": "16.1.4",
-        "@next/swc-linux-x64-musl": "16.1.4",
-        "@next/swc-win32-arm64-msvc": "16.1.4",
-        "@next/swc-win32-x64-msvc": "16.1.4",
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.563.0",
-    "next": "16.1.4",
+    "next": "16.1.6",
     "next-themes": "0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -33,7 +33,7 @@
     "@types/react": "19.2.9",
     "@types/react-dom": "19.2.3",
     "eslint": "9.39.2",
-    "eslint-config-next": "16.1.4",
+    "eslint-config-next": "16.1.6",
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3"
   },


### PR DESCRIPTION
## **PR Description**

### Summary

This PR removes **Devnet** support from the Faucet application and standardizes all logic to **Testnet only**.

Devnet will be reintroduced once there is a fully working Devnet bridge and/or faucet implementation.

---

### Changes

* Removed `Devnet` from all `NetworkType` unions.
* Removed Devnet configuration from:

  * `metamask-button.tsx`
  * `use-get-xrp.ts`
  * `use-poll-destination-tx-status.ts`
  * `bridging-progress.tsx`
* Removed network selector UI (Testnet is now the only available option).
* Hardcoded:

  * Testnet Chain ID (`1449000`)
  * Testnet explorer endpoints
  * Testnet token address
* Updated dependencies:

  * `next` → `16.1.6`
  * `eslint-config-next` → `16.1.6`

---

### Why

Devnet currently does not have a stable:

* Bridge implementation
* Faucet flow

To avoid user confusion and broken flows, the Faucet is now strictly Testnet until Devnet infrastructure is production-ready.

---

### Result

* Simpler network logic
* Reduced branching
* Cleaner UX (no non-functional network option)
* Safer user experience

Devnet support can be restored in a future PR once infrastructure is confirmed stable.
