### PR TITLE
Add Devnet faucet support and transaction confirmation polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Private key of the funded EOA authorised to call mint() on the
+# native XRP ERC20 (0xEee...EEeE) on XRPL EVM Devnet.
+# With or without the 0x prefix. Never commit the real value.
+DEVNET_FAUCET_PRIVATE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Testnet flow works without any env vars. The Devnet flow requires `DEVNET_FA
 
 ### `POST /api/devnet-faucet`
 
-Mints 100 XRP to the supplied address on XRPL EVM Devnet.
+Submits a `mint(address, 100e18)` transaction on XRPL EVM Devnet and returns the broadcast hash. Confirmation is the client's job — see `lib/use-poll-devnet-tx-status.ts`, which polls `eth_getTransactionReceipt` against the public RPC every 2s for up to ~2 min.
 
 Request:
 ```json
@@ -49,9 +49,7 @@ Response (200):
 
 Errors:
 - `400` — invalid JSON body or invalid EVM address
-- `500` — `DEVNET_FAUCET_PRIVATE_KEY` not configured, mint reverted, or RPC error
-
-The route waits up to 30s for the mint receipt before responding. If the receipt times out, the response still returns the submitted hash so the client can link to the explorer.
+- `500` — `DEVNET_FAUCET_PRIVATE_KEY` not configured or `writeContract` rejected (e.g. signer lacks mint permission, RPC down)
 
 ## Environment variables
 
@@ -81,6 +79,7 @@ components/
 lib/
   use-get-xrp.ts                 Testnet bridge flow (XRPL faucet → bridge payment)
   use-mint-xrp.ts                Devnet flow (POST to API route)
+  use-poll-devnet-tx-status.ts        eth_getTransactionReceipt polling (Devnet only)
   use-poll-destination-tx-status.ts   Axelar + explorer polling (Testnet only)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,91 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# XRPL EVM Faucet
 
-## Getting Started
+Web faucet for the XRPL EVM Sidechain. Supports two networks:
 
-First, run the development server:
+- **Testnet** — bridges XRP from XRPL Testnet through the Axelar gateway. The Ripple altnet faucet funds an ephemeral XRPL wallet, which then sends a `Payment` carrying interchain-transfer memos to the bridge gateway. Status is tracked client-side by polling Axelar's GMP indexer (primary) and the XRPL EVM explorer's token-transfers endpoint (fallback).
+- **Devnet** — mints XRP directly. The browser POSTs the user's address to a Vercel API route (`/api/devnet-faucet`), which signs `mint(address, 100e18)` against the native XRP ERC20 at `0xEee…EEeE` using a server-held private key.
+
+Built with Next.js 16 (App Router), React 19, Tailwind v4, viem, and `xrpl@4.5`.
+
+## Networks
+
+| | Testnet | Devnet |
+| --- | --- | --- |
+| Chain ID | `1449000` (`0x161228`) | `1449900` (`0x161FAC`) |
+| RPC | `https://rpc.testnet.xrplevm.org/` | `https://rpc.devnet.xrplevm.org/` |
+| Explorer | `https://explorer.testnet.xrplevm.org` | `https://explorer.devnet.xrplevm.org` |
+| Faucet amount | 97 XRP | 100 XRP |
+| Mechanism | XRPL → bridge | Direct ERC20 mint |
+| Anti-abuse | None (open) | None (open) |
+
+## Local development
 
 ```bash
+npm install
+cp .env.example .env.local
+# fill in DEVNET_FAUCET_PRIVATE_KEY
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:5089](http://localhost:5089).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+The Testnet flow works without any env vars. The Devnet flow requires `DEVNET_FAUCET_PRIVATE_KEY` to be set to a funded EOA that has permission to call `mint` on the native XRP ERC20.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## API
 
-## Learn More
+### `POST /api/devnet-faucet`
 
-To learn more about Next.js, take a look at the following resources:
+Mints 100 XRP to the supplied address on XRPL EVM Devnet.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Request:
+```json
+{ "address": "0x..." }
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Response (200):
+```json
+{ "txHash": "0x..." }
+```
 
-## Deploy on Vercel
+Errors:
+- `400` — invalid JSON body or invalid EVM address
+- `500` — `DEVNET_FAUCET_PRIVATE_KEY` not configured, mint reverted, or RPC error
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The route waits up to 30s for the mint receipt before responding. If the receipt times out, the response still returns the submitted hash so the client can link to the explorer.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DEVNET_FAUCET_PRIVATE_KEY` | Yes (Devnet only) | EOA private key authorised to call `mint(address,uint256)` on `0xEee…EEeE`. With or without the `0x` prefix. |
+
+See `.env.example`.
+
+## Deployment
+
+The project deploys to Vercel as-is — `app/api/devnet-faucet/route.ts` is picked up as a serverless function automatically. Set `DEVNET_FAUCET_PRIVATE_KEY` in the Vercel project's environment variables (Production + Preview as needed) before the first deploy.
+
+## Project layout
+
+```
+app/
+  page.tsx                       Single-page UI shell
+  layout.tsx                     Root layout, fonts, branding
+  api/devnet-faucet/route.ts     Devnet mint endpoint
+components/
+  faucet.tsx                     Main faucet form (network selector, request flow, modal)
+  connect-wallet-button.tsx      MetaMask connect / disconnect
+  metamask-button.tsx            "Add network to MetaMask" buttons + chain configs
+  bridging-progress.tsx          Spinner + rotating trivia (Testnet only)
+  ...
+lib/
+  use-get-xrp.ts                 Testnet bridge flow (XRPL faucet → bridge payment)
+  use-mint-xrp.ts                Devnet flow (POST to API route)
+  use-poll-destination-tx-status.ts   Axelar + explorer polling (Testnet only)
+```
+
+## Notes
+
+- The "Follow on X" / "Join Discord" gate is a client-side honor system, not a security check.
+- The Devnet endpoint has no rate limit or anti-bot protection. If you need either later, the natural fit is Upstash Redis for per-address / per-IP `SET NX EX` rate limits, plus Cloudflare Turnstile for browser attestation.
+- Concurrent Devnet requests share one signer key; viem auto-fetches nonces per call, so simultaneous requests can collide. If traffic warrants it, add a queue or use viem's nonce manager.

--- a/app/api/devnet-faucet/route.ts
+++ b/app/api/devnet-faucet/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  http,
+  isAddress,
+  parseEther,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NATIVE_XRP_ERC20 = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" as const;
+const MINT_AMOUNT = parseEther("100");
+// Receipt wait window — XRPL EVM finalises in ~5s, so 30s is generous.
+const RECEIPT_TIMEOUT_MS = 30_000;
+
+const xrplEvmDevnet = defineChain({
+  id: 1449900,
+  name: "XRPL EVM Devnet",
+  nativeCurrency: { name: "XRP", symbol: "XRP", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.devnet.xrplevm.org"] } },
+});
+
+const mintAbi = [
+  {
+    type: "function",
+    name: "mint",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const address = (body as { address?: unknown })?.address;
+  if (typeof address !== "string" || !isAddress(address)) {
+    return NextResponse.json({ error: "Invalid EVM address" }, { status: 400 });
+  }
+
+  const rawKey = process.env.DEVNET_FAUCET_PRIVATE_KEY;
+  if (!rawKey) {
+    console.error("[devnet-faucet] DEVNET_FAUCET_PRIVATE_KEY is not set");
+    return NextResponse.json({ error: "Faucet not configured" }, { status: 500 });
+  }
+  const pk = (rawKey.startsWith("0x") ? rawKey : `0x${rawKey}`) as `0x${string}`;
+
+  const account = privateKeyToAccount(pk);
+  const transport = http();
+  const walletClient = createWalletClient({ account, chain: xrplEvmDevnet, transport });
+  const publicClient = createPublicClient({ chain: xrplEvmDevnet, transport });
+
+  let txHash: `0x${string}`;
+  try {
+    txHash = await walletClient.writeContract({
+      address: NATIVE_XRP_ERC20,
+      abi: mintAbi,
+      functionName: "mint",
+      args: [address, MINT_AMOUNT],
+    });
+  } catch (err) {
+    console.error("[devnet-faucet] writeContract failed", err);
+    const message = err instanceof Error ? err.message : "Mint submission failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  try {
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+      timeout: RECEIPT_TIMEOUT_MS,
+    });
+    if (receipt.status !== "success") {
+      return NextResponse.json(
+        { error: "Mint reverted on-chain", txHash },
+        { status: 500 },
+      );
+    }
+  } catch (err) {
+    // Receipt timed out — the tx is still pending. Return the hash so the client
+    // can link to the explorer; not treating this as a hard error.
+    console.warn("[devnet-faucet] receipt wait timed out", err);
+  }
+
+  return NextResponse.json({ txHash });
+}

--- a/app/api/devnet-faucet/route.ts
+++ b/app/api/devnet-faucet/route.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  createPublicClient,
-  createWalletClient,
-  defineChain,
-  http,
-  isAddress,
-  parseEther,
-} from "viem";
+import { createWalletClient, defineChain, http, isAddress, parseEther } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 export const runtime = "nodejs";
@@ -14,8 +7,6 @@ export const dynamic = "force-dynamic";
 
 const NATIVE_XRP_ERC20 = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" as const;
 const MINT_AMOUNT = parseEther("100");
-// Receipt wait window — XRPL EVM finalises in ~5s, so 30s is generous.
-const RECEIPT_TIMEOUT_MS = 30_000;
 
 const xrplEvmDevnet = defineChain({
   id: 1449900,
@@ -58,40 +49,19 @@ export async function POST(req: NextRequest) {
   const pk = (rawKey.startsWith("0x") ? rawKey : `0x${rawKey}`) as `0x${string}`;
 
   const account = privateKeyToAccount(pk);
-  const transport = http();
-  const walletClient = createWalletClient({ account, chain: xrplEvmDevnet, transport });
-  const publicClient = createPublicClient({ chain: xrplEvmDevnet, transport });
+  const walletClient = createWalletClient({ account, chain: xrplEvmDevnet, transport: http() });
 
-  let txHash: `0x${string}`;
   try {
-    txHash = await walletClient.writeContract({
+    const txHash = await walletClient.writeContract({
       address: NATIVE_XRP_ERC20,
       abi: mintAbi,
       functionName: "mint",
       args: [address, MINT_AMOUNT],
     });
+    return NextResponse.json({ txHash });
   } catch (err) {
     console.error("[devnet-faucet] writeContract failed", err);
     const message = err instanceof Error ? err.message : "Mint submission failed";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  try {
-    const receipt = await publicClient.waitForTransactionReceipt({
-      hash: txHash,
-      timeout: RECEIPT_TIMEOUT_MS,
-    });
-    if (receipt.status !== "success") {
-      return NextResponse.json(
-        { error: "Mint reverted on-chain", txHash },
-        { status: 500 },
-      );
-    }
-  } catch (err) {
-    // Receipt timed out — the tx is still pending. Return the hash so the client
-    // can link to the explorer; not treating this as a hard error.
-    console.warn("[devnet-faucet] receipt wait timed out", err);
-  }
-
-  return NextResponse.json({ txHash });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { Faucet } from "@/components/faucet";
 import { Footer } from "@/components/footer";
 
 export default function Home() {
-  const [network, setNetwork] = useState<"Testnet">("Testnet");
+  const [network, setNetwork] = useState<"Testnet" | "Devnet">("Testnet");
 
   // We’ll track if we are mounted so SSR doesn’t mismatch client logic
   const [isMounted, setIsMounted] = useState(false);

--- a/components/faucet.tsx
+++ b/components/faucet.tsx
@@ -7,6 +7,7 @@ import { MetamaskButton } from "./metamask-button";
 import { useGetXrp } from "@/lib/use-get-xrp";
 import { useMintXrp } from "@/lib/use-mint-xrp";
 import { usePollDestinationTxStatus } from "../lib/use-poll-destination-tx-status";
+import { usePollDevnetTxStatus } from "@/lib/use-poll-devnet-tx-status";
 import type { MetaMaskInpageProvider } from "@metamask/providers";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "./ui/select";
 import { Input } from "./ui/input";
@@ -57,7 +58,9 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   const [showTxModal, setShowTxModal] = useState<boolean>(false);
   const [showInvalidAddressModal, setShowInvalidAddressModal] = useState<boolean>(false);
   const [chainId, setChainId] = useState<string | null>(null);
-  const [devnetStatus, setDevnetStatus] = useState<"Pending" | "Arrived" | "Failed">("Pending");
+  // Pre-submit failure state (e.g. mint API call rejected before producing a hash).
+  // Once `devnetTxHash` is set, the polling hook becomes the source of truth.
+  const [devnetSubmitError, setDevnetSubmitError] = useState<boolean>(false);
   const [devnetTxHash, setDevnetTxHash] = useState<string | null>(null);
 
   const ethereum = getEthereumProvider();
@@ -65,6 +68,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
 
   const getXrp = useGetXrp("testnet");
   const mintXrp = useMintXrp();
+  const { status: devnetPollStatus } = usePollDevnetTxStatus(devnetTxHash ?? "");
 
   useEffect(() => {
     setEvmAddress(evmAddressFromHeader || "");
@@ -115,17 +119,16 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
 
     setLoading(true);
     if (network === "Devnet") {
-      setDevnetStatus("Pending");
+      setDevnetSubmitError(false);
       setDevnetTxHash(null);
       setTxData({ txHash: "", sourceCloseTimeIso: "" });
       setShowTxModal(true);
       try {
         const hash = await mintXrp(evmAddress);
-        setDevnetTxHash(hash);
-        setDevnetStatus("Arrived");
+        setDevnetTxHash(hash); // hands off to usePollDevnetTxStatus
       } catch (error: unknown) {
         console.error("Error minting devnet XRP:", error);
-        setDevnetStatus("Failed");
+        setDevnetSubmitError(true);
         alert("Error minting devnet XRP: " + (error instanceof Error ? error.message : String(error)));
       } finally {
         setLoading(false);
@@ -163,7 +166,11 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
     if (!txData) return null;
 
     const isDevnet = network === "Devnet";
-    const effectiveStatus = isDevnet ? devnetStatus : status;
+    const effectiveStatus = isDevnet
+      ? devnetSubmitError
+        ? "Failed"
+        : devnetPollStatus
+      : status;
     const effectiveTxHash = isDevnet ? devnetTxHash : destinationTxHash;
 
     let displayedStatus = "";
@@ -195,10 +202,14 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
         onOpenChange={(open) => {
           setShowTxModal(open);
           // Devnet has no rate-limit: let the user request again after closing a terminal-state modal.
-          if (!open && isDevnet && (devnetStatus === "Arrived" || devnetStatus === "Failed")) {
+          const terminal =
+            effectiveStatus === "Arrived" ||
+            effectiveStatus === "Failed" ||
+            effectiveStatus === "Timeout";
+          if (!open && isDevnet && terminal) {
             setTxData(null);
             setDevnetTxHash(null);
-            setDevnetStatus("Pending");
+            setDevnetSubmitError(false);
           }
         }}
       >

--- a/components/faucet.tsx
+++ b/components/faucet.tsx
@@ -5,6 +5,7 @@ import { Logo } from "./logo";
 import { ConnectWalletButton } from "./connect-wallet-button";
 import { MetamaskButton } from "./metamask-button";
 import { useGetXrp } from "@/lib/use-get-xrp";
+import { useMintXrp } from "@/lib/use-mint-xrp";
 import { usePollDestinationTxStatus } from "../lib/use-poll-destination-tx-status";
 import type { MetaMaskInpageProvider } from "@metamask/providers";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "./ui/select";
@@ -12,7 +13,22 @@ import { Input } from "./ui/input";
 import Link from "next/link";
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 
-export type NetworkType = "Testnet";
+export type NetworkType = "Testnet" | "Devnet";
+
+const FAUCET_AMOUNTS: Record<NetworkType, number> = {
+  Testnet: 97,
+  Devnet: 100,
+};
+
+const CHAIN_IDS: Record<NetworkType, number> = {
+  Testnet: 1449000,
+  Devnet: 1449900,
+};
+
+const EXPLORER_BASES: Record<NetworkType, string> = {
+  Testnet: "https://explorer.testnet.xrplevm.org",
+  Devnet: "https://explorer.devnet.xrplevm.org",
+};
 
 interface FaucetProps {
   network: NetworkType;
@@ -41,11 +57,14 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   const [showTxModal, setShowTxModal] = useState<boolean>(false);
   const [showInvalidAddressModal, setShowInvalidAddressModal] = useState<boolean>(false);
   const [chainId, setChainId] = useState<string | null>(null);
+  const [devnetStatus, setDevnetStatus] = useState<"Pending" | "Arrived" | "Failed">("Pending");
+  const [devnetTxHash, setDevnetTxHash] = useState<string | null>(null);
 
   const ethereum = getEthereumProvider();
   const hasMetaMask: boolean = Boolean(ethereum);
 
-  const getXrp = useGetXrp(network.toLowerCase() as "testnet");
+  const getXrp = useGetXrp("testnet");
+  const mintXrp = useMintXrp();
 
   useEffect(() => {
     setEvmAddress(evmAddressFromHeader || "");
@@ -95,6 +114,25 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
     }
 
     setLoading(true);
+    if (network === "Devnet") {
+      setDevnetStatus("Pending");
+      setDevnetTxHash(null);
+      setTxData({ txHash: "", sourceCloseTimeIso: "" });
+      setShowTxModal(true);
+      try {
+        const hash = await mintXrp(evmAddress);
+        setDevnetTxHash(hash);
+        setDevnetStatus("Arrived");
+      } catch (error: unknown) {
+        console.error("Error minting devnet XRP:", error);
+        setDevnetStatus("Failed");
+        alert("Error minting devnet XRP: " + (error instanceof Error ? error.message : String(error)));
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+
     try {
       const txHash = await getXrp(evmAddress);
       const closeTimeIso = new Date().toISOString();
@@ -109,7 +147,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   };
 
   function getDesiredChainId(network: NetworkType): string {
-    return "0x" + Number(1449000).toString(16);
+    return "0x" + CHAIN_IDS[network].toString(16);
   }
   const desiredChainId: string = getDesiredChainId(network);
   const isOnDesiredChain: boolean = !!chainId && chainId.toLowerCase() === desiredChainId.toLowerCase();
@@ -124,12 +162,16 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
   const TransactionStatusModal = (): JSX.Element | null => {
     if (!txData) return null;
 
+    const isDevnet = network === "Devnet";
+    const effectiveStatus = isDevnet ? devnetStatus : status;
+    const effectiveTxHash = isDevnet ? devnetTxHash : destinationTxHash;
+
     let displayedStatus = "";
     let extraMessage = "";
-    switch (status) {
+    switch (effectiveStatus) {
       case "Pending":
         displayedStatus = "Pending";
-        extraMessage = "Estimated time: ~2 minutes";
+        extraMessage = isDevnet ? "Minting…" : "Estimated time: ~2 minutes";
         break;
       case "Arrived":
         displayedStatus = "Done";
@@ -141,18 +183,25 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
         extraMessage = "Transaction failed or timed out. Please try again.";
         break;
       default:
-        displayedStatus = status || "Pending";
+        displayedStatus = effectiveStatus || "Pending";
         break;
     }
-    const evmTxUrl = destinationTxHash
-      ? network === "Testnet"
-        ? `https://explorer.testnet.xrplevm.org/tx/${destinationTxHash}`
-        : `https://explorer.xrplevm.org/tx/${destinationTxHash}`
-      : null;
-    const bridgingTimeSec = bridgingTimeMs ? Math.floor(bridgingTimeMs / 1000) : 0;
+    const evmTxUrl = effectiveTxHash ? `${EXPLORER_BASES[network]}/tx/${effectiveTxHash}` : null;
+    const bridgingTimeSec = !isDevnet && bridgingTimeMs ? Math.floor(bridgingTimeMs / 1000) : 0;
 
     return (
-      <AlertDialog open={showTxModal} onOpenChange={setShowTxModal}>
+      <AlertDialog
+        open={showTxModal}
+        onOpenChange={(open) => {
+          setShowTxModal(open);
+          // Devnet has no rate-limit: let the user request again after closing a terminal-state modal.
+          if (!open && isDevnet && (devnetStatus === "Arrived" || devnetStatus === "Failed")) {
+            setTxData(null);
+            setDevnetTxHash(null);
+            setDevnetStatus("Pending");
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Transaction Status</AlertDialogTitle>
@@ -170,7 +219,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
             </div>
             {extraMessage && <span className="text-sm text-gray-400">{extraMessage}</span>}
 
-            {displayedStatus === "Pending" && <BridgingProgress />}
+            {displayedStatus === "Pending" && !isDevnet && <BridgingProgress />}
 
             {displayedStatus === "Done" && evmTxUrl && (
               <div className="flex flex-col gap-1">
@@ -181,7 +230,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
                   rel="noopener noreferrer"
                   className="text-green-400 underline break-all hover:text-green-300"
                 >
-                  {destinationTxHash}
+                  {effectiveTxHash}
                 </Link>
               </div>
             )}
@@ -231,6 +280,21 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
           ) : (
             <MetamaskButton className="h-10" network={network} />
           )}
+        </div>
+
+        <div className="flex flex-col items-center gap-1">
+          <label htmlFor="network" className="font-semibold">
+            Network
+          </label>
+          <Select value={network} onValueChange={(v) => setNetwork(v as NetworkType)}>
+            <SelectTrigger id="network" className="w-[300px] md:w-[459px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Testnet">Testnet</SelectItem>
+              <SelectItem value="Devnet">Devnet</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="flex flex-col items-center gap-1">
@@ -285,7 +349,7 @@ export function Faucet({ network, setNetwork, evmAddressFromHeader }: FaucetProp
           onClick={handleRequestXRP}
           disabled={!!txData || loading}
         >
-          {loading ? `Waiting ~...` : "Request 97 XRP"}
+          {loading ? `Waiting ~...` : `Request ${FAUCET_AMOUNTS[network]} XRP`}
         </Button>
       </section>
 

--- a/components/metamask-button.tsx
+++ b/components/metamask-button.tsx
@@ -29,9 +29,26 @@ const TESTNET_CONFIG = {
   blockExplorerUrls: ["https://explorer.testnet.xrplevm.org"],
 };
 
-type NetworkType = "Testnet";
+const DEVNET_CONFIG = {
+  chainId: "0x" + Number(1449900).toString(16),
+  chainName: "XRPL EVM Sidechain Devnet",
+  nativeCurrency: {
+    name: "XRP",
+    symbol: "XRP",
+    decimals: 18,
+  },
+  rpcUrls: ["https://rpc.devnet.xrplevm.org/"],
+  blockExplorerUrls: ["https://explorer.devnet.xrplevm.org"],
+};
 
-/** 
+type NetworkType = "Testnet" | "Devnet";
+
+const NETWORK_CONFIGS: Record<NetworkType, typeof TESTNET_CONFIG> = {
+  Testnet: TESTNET_CONFIG,
+  Devnet: DEVNET_CONFIG,
+};
+
+/**
  * ✅ Common logic for requesting a network add/switch in MetaMask
  * If MetaMask not installed, redirects to installation page.
  */
@@ -41,7 +58,7 @@ async function addNetworkToMetamask(network: NetworkType) {
     return;
   }
 
-  const selectedConfig = TESTNET_CONFIG;
+  const selectedConfig = NETWORK_CONFIGS[network];
 
   try {
     await window.ethereum.request({

--- a/lib/use-get-xrp.ts
+++ b/lib/use-get-xrp.ts
@@ -15,32 +15,76 @@ export type Network = "testnet";
 
 export const useGetXrp = (network: Network) => {
   return async function (destination: string) {
-    const wallet = Wallet.generate();
+    console.log("[faucet] === starting request ===", { network, destination });
 
+    const wallet = Wallet.generate();
+    console.log("[faucet] 1) generated ephemeral wallet", { address: wallet.address });
+
+    console.log("[faucet] 2) POST to ripple faucet", networks[network].faucet);
     const resp = await fetch(networks[network].faucet, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ destination: wallet.address }),
     });
+    console.log("[faucet] 2) faucet HTTP status", resp.status, resp.statusText);
 
     const json = await resp.json();
+    console.log("[faucet] 2) faucet response body", json);
 
+    if (!resp.ok) {
+      throw new Error(`Ripple faucet returned ${resp.status}: ${JSON.stringify(json)}`);
+    }
+    if (typeof json.amount !== "number") {
+      throw new Error(`Ripple faucet response missing 'amount': ${JSON.stringify(json)}`);
+    }
+
+    console.log("[faucet] 3) waiting 1s for XRPL ledger to settle");
     await new Promise((res) => setTimeout(res, 1000));
 
     const amount = json.amount - reserve;
     const roundedAmount = Math.round(amount * 1e6) / 1e6;
+    console.log("[faucet] 4) bridging amount (XRP)", { received: json.amount, reserve, sending: roundedAmount });
 
     const tx = prepareBridgeTransaction(wallet.address, network, destination, roundedAmount);
+    console.log("[faucet] 5) prepared bridge tx", tx);
 
+    console.log("[faucet] 6) connecting to XRPL", networks[network].wsUrl);
     const client = new Client(networks[network].wsUrl);
     await client.connect();
+    console.log("[faucet] 6) connected");
 
-    const prepared = await client.autofill(tx);
+    let prepared;
+    try {
+      prepared = await client.autofill(tx);
+      // autofill defaults LastLedgerSequence to currentLedger + 20 (~60-80s).
+      // Testnet can be slow enough that submitAndWait sees the window expire by 1-2 ledgers
+      // even though the tx submitted with tesSUCCESS. Widen to ~5 minutes.
+      prepared.LastLedgerSequence = (prepared.LastLedgerSequence ?? 0) + 75;
+      console.log("[faucet] 7) autofilled tx (LLS extended)", prepared);
+    } catch (err) {
+      console.error("[faucet] 7) autofill FAILED — ephemeral account likely not yet on ledger", err);
+      throw err;
+    }
 
     const signed = wallet.sign(prepared);
+    console.log("[faucet] 8) signed tx", { hash: signed.hash });
 
-    const res = await client.submitAndWait(signed.tx_blob);
+    let res;
+    try {
+      res = await client.submitAndWait(signed.tx_blob);
+      console.log("[faucet] 9) submitAndWait result", res.result);
+    } catch (err) {
+      console.error("[faucet] 9) submitAndWait FAILED — bridge payment rejected", err);
+      throw err;
+    }
 
+    const meta = res.result.meta;
+    const engineResult = typeof meta === "object" && meta !== null && "TransactionResult" in meta ? meta.TransactionResult : undefined;
+    if (engineResult && engineResult !== "tesSUCCESS") {
+      console.warn("[faucet] 9) tx submitted but engine result is not tesSUCCESS:", engineResult);
+    }
+
+    console.log("[faucet] === done ===", { hash: res.result.hash });
     return res.result.hash;
   };
 };

--- a/lib/use-mint-xrp.ts
+++ b/lib/use-mint-xrp.ts
@@ -1,0 +1,25 @@
+export const useMintXrp = () => {
+  return async function (destination: string): Promise<string> {
+    console.log("[devnet-faucet] === starting mint request ===", { destination });
+
+    const resp = await fetch("/api/devnet-faucet", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address: destination }),
+    });
+
+    let json: { txHash?: string; error?: string };
+    try {
+      json = await resp.json();
+    } catch {
+      throw new Error(`Faucet returned ${resp.status} with non-JSON body`);
+    }
+
+    if (!resp.ok || !json.txHash) {
+      throw new Error(json.error ?? `Faucet returned ${resp.status}`);
+    }
+
+    console.log("[devnet-faucet] === mint done ===", { txHash: json.txHash });
+    return json.txHash;
+  };
+};

--- a/lib/use-poll-destination-tx-status.ts
+++ b/lib/use-poll-destination-tx-status.ts
@@ -45,13 +45,15 @@ export function usePollDestinationTxStatus(
   destinationAddress: string,
   sourceCloseTimeIso: string,
   txHash: string,
-  network: "Testnet"
+  network: "Testnet" | "Devnet"
 ) {
   const [status, setStatus] = useState<"Pending" | "Arrived" | "Timeout" | "Failed">("Pending");
   const [destinationTxHash, setDestinationTxHash] = useState<string | null>(null);
   const [bridgingTimeMs, setBridgingTimeMs] = useState<number | null>(null);
 
   useEffect(() => {
+    // Devnet has no bridge — the EVM tx IS the result, so nothing to poll.
+    if (network !== "Testnet") return;
     if (!txHash) return;
 
     const startedAtMs = sourceCloseTimeIso ? new Date(sourceCloseTimeIso).getTime() : Date.now();
@@ -73,7 +75,7 @@ export function usePollDestinationTxStatus(
     const pollAxelar = async () => {
       if (arrived) return;
       try {
-        const url = `${AXELAR_API[network]}?txHash=${txHash}`;
+        const url = `${AXELAR_API.Testnet}?txHash=${txHash}`;
         const resp = await axios.get<AxelarResponse>(url);
         const records = resp.data?.data ?? [];
         console.log("[bridge-status][axelar] poll", { total: resp.data?.total, records: records.length });
@@ -115,7 +117,7 @@ export function usePollDestinationTxStatus(
       if (!destinationAddress || !sourceCloseTimeIso) return;
       try {
         const url =
-          `${EVM_EXPLORER_API[network]}/${destinationAddress}/token-transfers` +
+          `${EVM_EXPLORER_API.Testnet}/${destinationAddress}/token-transfers` +
           `?type=ERC-20` +
           `&filter=${destinationAddress}%20|%200x0000000000000000000000000000000000000000` +
           `&token=${NATIVE_TOKEN_ADDRESS}`;

--- a/lib/use-poll-destination-tx-status.ts
+++ b/lib/use-poll-destination-tx-status.ts
@@ -1,7 +1,36 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 
-// Define a type for a token transfer item:
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_ATTEMPTS = 300; // ~25 min
+
+const AXELAR_API: Record<"Testnet", string> = {
+  Testnet: "https://testnet.api.axelarscan.io/gmp/searchGMP",
+};
+
+const EVM_EXPLORER_API: Record<"Testnet", string> = {
+  Testnet: "https://explorer.testnet.xrplevm.org/api/v2/addresses",
+};
+
+const NATIVE_TOKEN_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const FAUCET_AMOUNT_XRP = 97.3;
+const AMOUNT_TOLERANCE_XRP = 3;
+
+interface AxelarRecord {
+  status?: string;
+  simplified_status?: string;
+  message_id?: string;
+  executed?: { transactionHash?: string; chain?: string };
+  call?: { chain?: string; transactionHash?: string };
+  interchain_transfer?: { rawDestinationAddress?: string; amount?: string };
+  error?: unknown;
+}
+
+interface AxelarResponse {
+  data: AxelarRecord[];
+  total: number;
+}
+
 interface TokenTransferItem {
   to: { hash: string };
   total: { value: string; decimals: string | number };
@@ -9,22 +38,9 @@ interface TokenTransferItem {
   transaction_hash: string;
 }
 
-const DEST_POLL_INTERVAL = 5000; // 5 seconds
-const MAX_POLL_ATTEMPTS = 300; // maximum attempts
+const FINAL_SUCCESS_STATUSES = new Set(["received", "executed"]);
+const FAILURE_STATUSES = new Set(["error", "failed", "insufficient_fee"]);
 
-/**
- * Custom hook that polls the destination chain for the faucet transaction.
- *
- * @param destinationAddress - The user's 0x address receiving funds.
- * @param sourceCloseTimeIso - The close_time_iso from the XRPL transaction.
- * @param txHash - The original XRPL transaction hash.
- * @param network - Testnet.
- *
- * @returns An object with:
- *  - status: "Pending", "Arrived", "Timeout", or "Failed"
- *  - destinationTxHash: the destination chain transaction hash (if arrived)
- *  - bridgingTimeMs: the difference between source close time and the destination tx time (if available)
- */
 export function usePollDestinationTxStatus(
   destinationAddress: string,
   sourceCloseTimeIso: string,
@@ -36,78 +52,116 @@ export function usePollDestinationTxStatus(
   const [bridgingTimeMs, setBridgingTimeMs] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!destinationAddress || !sourceCloseTimeIso || !txHash) return;
+    if (!txHash) return;
 
+    const startedAtMs = sourceCloseTimeIso ? new Date(sourceCloseTimeIso).getTime() : Date.now();
+    let arrived = false;
     let attempts = 0;
-    const faucetAmount = 97.3; // expected faucet amount
 
-    const poll = async () => {
-      attempts++;
+    const markArrived = (destTx: string, source: "axelar" | "explorer") => {
+      if (arrived) return;
+      arrived = true;
+      console.log(`[bridge-status] arrived (via ${source})`, { destTx });
+      setDestinationTxHash(destTx);
+      setBridgingTimeMs(Date.now() - startedAtMs);
+      setStatus("Arrived");
+    };
 
+    // Primary signal: Axelar's GMP indexer.
+    // Reports the bridge's own view of the transfer (called/approved/executing/executed).
+    // Reliable when the indexer is healthy; misses transfers when the relayer is offline or lagged.
+    const pollAxelar = async () => {
+      if (arrived) return;
       try {
-        // 1) Construct the explorer API URL based on network.
-        const explorerBaseUrl = "https://explorer.testnet.xrplevm.org/api/v2/addresses";
-        const tokenAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
-        const url =
-          `${explorerBaseUrl}/${destinationAddress}/token-transfers` +
-          `?type=ERC-20` +
-          `&filter=${destinationAddress}%20|%200x0000000000000000000000000000000000000000` +
-          `&token=${tokenAddress}`;
+        const url = `${AXELAR_API[network]}?txHash=${txHash}`;
+        const resp = await axios.get<AxelarResponse>(url);
+        const records = resp.data?.data ?? [];
+        console.log("[bridge-status][axelar] poll", { total: resp.data?.total, records: records.length });
 
-        // 2) Fetch transfers data.
-        let items: TokenTransferItem[] = [];
-        try {
-          const resp = await axios.get(url);
-          items = resp.data.items as TokenTransferItem[];
-        } catch (error) {
-          if (axios.isAxiosError(error)) {
-            if (error.response?.status === 404) {
-              // No transfers found yet, continue polling
-            } else {
-              setStatus("Failed");
-            }
-          } else {
-            setStatus("Failed");
-          }
+        if (records.length === 0) return; // not indexed yet
+
+        const evmLeg = records.find(
+          (r) =>
+            r.executed?.transactionHash?.startsWith("0x") &&
+            (FINAL_SUCCESS_STATUSES.has(r.simplified_status ?? "") ||
+              FINAL_SUCCESS_STATUSES.has(r.status ?? ""))
+        );
+        if (evmLeg?.executed?.transactionHash) {
+          markArrived(evmLeg.executed.transactionHash, "axelar");
+          return;
         }
 
-        // 3) Find a matching transfer:
+        const errored = records.find(
+          (r) =>
+            FAILURE_STATUSES.has(r.simplified_status ?? "") ||
+            FAILURE_STATUSES.has(r.status ?? "") ||
+            r.error
+        );
+        if (errored && !arrived) {
+          // Tentative failure — explorer fallback can still upgrade to Arrived later.
+          console.error("[bridge-status][axelar] reports failure (tentative)", errored);
+          setStatus("Failed");
+        }
+      } catch (err) {
+        console.error("[bridge-status][axelar] query failed", err);
+      }
+    };
+
+    // Fallback signal: scan the EVM explorer for a matching ERC-20 transfer to the user's address.
+    // Independent of Axelar's indexer — finds the funds even if Axelar never indexes the message.
+    // Less precise: matches by amount window + timestamp rather than by source-tx linkage.
+    const pollExplorer = async () => {
+      if (arrived) return;
+      if (!destinationAddress || !sourceCloseTimeIso) return;
+      try {
+        const url =
+          `${EVM_EXPLORER_API[network]}/${destinationAddress}/token-transfers` +
+          `?type=ERC-20` +
+          `&filter=${destinationAddress}%20|%200x0000000000000000000000000000000000000000` +
+          `&token=${NATIVE_TOKEN_ADDRESS}`;
+        const resp = await axios.get<{ items: TokenTransferItem[] }>(url);
+        const items = resp.data?.items ?? [];
+        console.log("[bridge-status][explorer] poll", { items: items.length });
+
+        const sourceTimeMs = new Date(sourceCloseTimeIso).getTime();
+
         for (const item of items) {
           if (!item?.to?.hash) continue;
           if (item.to.hash.toLowerCase() !== destinationAddress.toLowerCase()) continue;
 
-          // Compare amounts
           const rawValueStr = item?.total?.value ?? "0";
           const decimals = parseInt(item?.total?.decimals.toString() ?? "18", 10);
           const floatVal = parseFloat(rawValueStr) / 10 ** decimals;
+          if (Math.abs(floatVal - FAUCET_AMOUNT_XRP) > AMOUNT_TOLERANCE_XRP) continue;
 
-          // Allow for a small difference in amount due to fees (within 3 XRP)
-          if (Math.abs(floatVal - faucetAmount) > 3) continue;
-
-          // Compare timestamps (only consider transfers after XRPL close time)
-          const evmTimestampIso = item.timestamp;
-          const evmTimeMs = new Date(evmTimestampIso).getTime();
-          const sourceTimeMs = new Date(sourceCloseTimeIso).getTime();
-
+          const evmTimeMs = new Date(item.timestamp).getTime();
           if (evmTimeMs <= sourceTimeMs) continue;
 
-          // Match found!
-          const bridgingTime = evmTimeMs - sourceTimeMs;
-          setStatus("Arrived");
-          setDestinationTxHash(item.transaction_hash);
-          setBridgingTimeMs(bridgingTime);
+          markArrived(item.transaction_hash, "explorer");
           return;
         }
-      } catch {
-        setStatus("Failed");
-      }
-
-      if (attempts >= MAX_POLL_ATTEMPTS) {
-        setStatus("Timeout");
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) return; // no transfers yet
+        console.error("[bridge-status][explorer] query failed", err);
       }
     };
 
-    const intervalId = setInterval(poll, DEST_POLL_INTERVAL);
+    const tick = () => {
+      attempts++;
+      if (attempts > MAX_POLL_ATTEMPTS) {
+        if (!arrived) {
+          console.warn("[bridge-status] both pollers timed out");
+          setStatus("Timeout");
+        }
+        clearInterval(intervalId);
+        return;
+      }
+      pollAxelar();
+      pollExplorer();
+    };
+
+    tick();
+    const intervalId = setInterval(tick, POLL_INTERVAL_MS);
     return () => clearInterval(intervalId);
   }, [destinationAddress, sourceCloseTimeIso, txHash, network]);
 

--- a/lib/use-poll-devnet-tx-status.ts
+++ b/lib/use-poll-devnet-tx-status.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from "react";
+
+const DEVNET_RPC = "https://rpc.devnet.xrplevm.org";
+const POLL_INTERVAL_MS = 2_000;
+const MAX_POLL_ATTEMPTS = 60; // ~2 min — XRPL EVM finalises in ~5s, so this is generous
+
+interface RpcReceipt {
+  status?: string;
+  blockNumber?: string;
+}
+
+export type DevnetTxStatus = "Pending" | "Arrived" | "Failed" | "Timeout";
+
+export function usePollDevnetTxStatus(txHash: string) {
+  const [status, setStatus] = useState<DevnetTxStatus>("Pending");
+
+  useEffect(() => {
+    setStatus("Pending");
+    if (!txHash) return;
+
+    let attempts = 0;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const tick = async () => {
+      attempts++;
+      if (attempts > MAX_POLL_ATTEMPTS) {
+        console.warn("[devnet-status] timed out waiting for receipt", { txHash });
+        setStatus("Timeout");
+        if (intervalId) clearInterval(intervalId);
+        return;
+      }
+
+      try {
+        const resp = await fetch(DEVNET_RPC, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "eth_getTransactionReceipt",
+            params: [txHash],
+            id: 1,
+          }),
+        });
+        const json: { result?: RpcReceipt | null } = await resp.json();
+        const receipt = json.result;
+
+        if (!receipt) return; // not mined yet
+
+        if (receipt.status === "0x1") {
+          console.log("[devnet-status] tx confirmed", { txHash });
+          setStatus("Arrived");
+          if (intervalId) clearInterval(intervalId);
+        } else if (receipt.status === "0x0") {
+          console.error("[devnet-status] tx reverted", { txHash });
+          setStatus("Failed");
+          if (intervalId) clearInterval(intervalId);
+        }
+      } catch (err) {
+        console.error("[devnet-status] poll failed", err);
+      }
+    };
+
+    tick();
+    intervalId = setInterval(tick, POLL_INTERVAL_MS);
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [txHash]);
+
+  return { status };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "19.2.3",
         "tailwind-merge": "3.4.0",
         "tailwindcss-animate": "1.0.7",
+        "viem": "^2.48.8",
         "xrpl": "4.5.0"
       },
       "devDependencies": {
@@ -36,6 +37,12 @@
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1422,6 +1429,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -3244,6 +3263,27 @@
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
         "ripple-keypairs": "^2.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -5719,6 +5759,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6610,6 +6665,84 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ox": {
+      "version": "0.14.20",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
+      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -7831,7 +7964,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8029,6 +8162,99 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/viem": {
+      "version": "2.48.8",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.8.tgz",
+      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.20",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webextension-polyfill": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
@@ -8223,7 +8449,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "19.2.3",
     "tailwind-merge": "3.4.0",
     "tailwindcss-animate": "1.0.7",
+    "viem": "^2.48.8",
     "xrpl": "4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**
Adds XRPL EVM Devnet support to the faucet alongside the existing Testnet bridge flow.

Changes include:

* Added network selector for Testnet and Devnet
* Added `/api/devnet-faucet` endpoint to mint 100 XRP on Devnet
* Added Devnet transaction receipt polling via `eth_getTransactionReceipt`
* Added MetaMask Devnet network configuration
* Improved Testnet bridge status tracking with AxelarScan as primary source and explorer fallback
* Updated README with setup, deployment, API, and environment variable instructions
* Added `.env.example` for `DEVNET_FAUCET_PRIVATE_KEY`
